### PR TITLE
Improve mobile grid sizing and add word list toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,13 +25,15 @@
         <div class="main-content">
             <div id="grid-container">
                 </div>
-            <div class="word-list-container">
+            <div class="word-list-container" id="word-list-container">
                 <h2>Mots à trouver :</h2>
                 <ul id="word-list">
                     </ul>
             </div>
         </div>
-        
+
+        <button id="toggle-word-list" class="mobile-toggle">Afficher les mots</button>
+
         <button id="start-btn">Commencer la partie</button>
 
     </div>

--- a/script.js
+++ b/script.js
@@ -2,9 +2,11 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- ÉLÉMENTS DU DOM ---
     const gridContainer = document.getElementById('grid-container');
     const wordListElement = document.getElementById('word-list');
+    const wordListContainer = document.getElementById('word-list-container');
     const scoreElement = document.getElementById('score');
     const timerElement = document.getElementById('timer');
     const startBtn = document.getElementById('start-btn');
+    const toggleWordListBtn = document.getElementById('toggle-word-list');
     const restartBtn = document.getElementById('restart-btn');
     const endGameOverlay = document.getElementById('end-game-overlay');
     const endGameTitle = document.getElementById('end-game-title');
@@ -124,6 +126,8 @@ document.addEventListener('DOMContentLoaded', () => {
         renderWordList();
         currentSelection = [];
         selectionDirection = null;
+        wordListContainer.classList.remove('show');
+        toggleWordListBtn.textContent = 'Afficher les mots';
     }
 
     function startGame() {
@@ -244,6 +248,10 @@ document.addEventListener('DOMContentLoaded', () => {
     // Ajout des lignes manquantes ici !
     startBtn.addEventListener('click', startGame);
     restartBtn.addEventListener('click', resetGame);
+    toggleWordListBtn.addEventListener('click', () => {
+        wordListContainer.classList.toggle('show');
+        toggleWordListBtn.textContent = wordListContainer.classList.contains('show') ? 'Masquer les mots' : 'Afficher les mots';
+    });
     addGridEventListeners();
 
     // --- INITIALISATION AU DÉMARRAGE ---

--- a/style.css
+++ b/style.css
@@ -199,17 +199,38 @@ button:hover {
 }
 
 @media (max-width: 480px) {
+    body {
+        padding: 0;
+    }
+    .game-container {
+        padding: 10px;
+    }
     #grid-container {
-        width: calc(100vw - 10px);
-        grid-template-columns: repeat(15, minmax(0, 1fr));
+        --cell-size: calc((100vmin - 36px) / 15);
+        width: calc(var(--cell-size) * 15);
+        height: calc(var(--cell-size) * 15);
+        grid-template-columns: repeat(15, var(--cell-size));
     }
     .cell {
-        font-size: min(4vw, 1em);
+        width: var(--cell-size);
+        height: var(--cell-size);
+        font-size: calc(var(--cell-size) * 0.6);
     }
     .word-list-container {
         margin-top: 10px;
+        display: none;
+    }
+    .word-list-container.show {
+        display: block;
     }
     #word-list {
         column-count: 1;
     }
+    #toggle-word-list {
+        display: block;
+    }
+}
+
+#toggle-word-list {
+    display: none;
 }


### PR DESCRIPTION
## Summary
- Compute mobile grid and cell sizes using viewport units to prevent horizontal scrolling
- Add toggle button on small screens to hide or show the word list
- Reset and manage toggle state via script for consistent behavior

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689672a9cd2483268e23d4d07a8cd357