### PR TITLE
Add touch event fallback with feature detection

### DIFF
--- a/script.js
+++ b/script.js
@@ -170,6 +170,12 @@ document.addEventListener('DOMContentLoaded', () => {
         gridContainer.addEventListener('pointercancel', handlePointerUp);
         document.addEventListener('pointerup', handlePointerUp);
         document.addEventListener('pointercancel', handlePointerUp);
+        if (!window.PointerEvent) {
+            gridContainer.addEventListener('touchstart', handlePointerDown, { passive: false });
+            gridContainer.addEventListener('touchmove', handlePointerMove, { passive: false });
+            gridContainer.addEventListener('touchend', handlePointerUp, { passive: false });
+            document.addEventListener('touchend', handlePointerUp, { passive: false });
+        }
     }
 
     function handlePointerDown(e) {


### PR DESCRIPTION
## Summary
- Add touch event listeners to grid setup when Pointer Events aren't supported
- Map touch events to existing pointer handlers to support older browsers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689672aa66d48326bcff0071c1b18fbd